### PR TITLE
[ENH] update schema following email discussion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ all:
 
 fullvalidateschema:
 	uv run bst export > src/schema.json
-dd	bids-validator-deno --schema file://${PWD}/src/schema.json ../bids-examples/ct001/ --verbose --ignoreWarnings --ignoreNiftiHeaders; \
+	bids-validator-deno --schema file://${PWD}/src/schema.json ../bids-examples/ct001/ --verbose --ignoreWarnings --ignoreNiftiHeaders; \
 	example_status=$$?; \
-	mkdocs build; \
+	uv run mkdocs build; \
 	build_status=$$?; \
 	echo "example_status: $$example_status"; \
 	echo "build_status: $$build_status"; \
@@ -45,5 +45,4 @@ dd	bids-validator-deno --schema file://${PWD}/src/schema.json ../bids-examples/c
 
 quickvalidateschema:
 	uv run bst export > src/schema.json
-	cat src/schema.json | jq '.rules.files.raw.ct.ct.entities.acquisition = "optional"' > src/schema.json.tmp && mv src/schema.json.tmp src/schema.json
 	bids-validator-deno --schema file://${PWD}/src/schema.json ../bids-examples/ct001/ --verbose --ignoreWarnings --ignoreNiftiHeaders; \

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -1167,20 +1167,6 @@ EthicsApprovals:
   type: array
   items:
     type: string
-Exposure:
-  name: Exposure
-  display_name: Exposure
-  description: |
-    X-Ray exposure of the patient in milliamperes seconds.
-  type: number
-  unit: mAs
-ExposureTime:
-  name: ExposureTime
-  display_name: Exposure Time
-  description: |
-    Time of X-Ray exposure in milliseconds.
-  type: number
-  unit: ms
 FiducialsCoordinateSystem:
   name: FiducialsCoordinateSystem
   display_name: Fiducials Coordinate System
@@ -3961,9 +3947,9 @@ TracerSNOMED:
     ID of the tracer compound from the SNOMED Ontology
     (subclass of Radioactive isotope).
   type: string
-TubeCurrent:
-  name: TubeCurrent
-  display_name: Tube Current
+XRayTubeCurrent:
+  name: XRayTubeCurrent
+  display_name: X-Ray Tube Current
   description: |
     X-Ray tube current in milliamperes.
   anyOf:
@@ -3973,9 +3959,9 @@ TubeCurrent:
       items:
         type: number
         unit: mA
-TubeVoltage:
-  name: TubeVoltage
-  display_name: Tube Voltage
+XRayTubeVoltage:
+  name: XRayTubeVoltage
+  display_name: X-Ray Tube Voltage
   description: |
     X-Ray tube peak kilo voltage (kVp) output.
   type: number
@@ -4237,3 +4223,17 @@ iEEGReference:
     this field should have a general description and the channel specific
     reference should be defined in the `channels.tsv` file.
   type: string
+XRayExposure:
+  name: XRayExposure
+  display_name: X-Ray Exposure
+  description: |
+    X-Ray exposure of the patient in milliamperes seconds.
+  type: number
+  unit: mAs
+XRayExposureTime:
+  name: XRayExposureTime
+  display_name: X-Ray Exposure Time
+  description: |
+    Time of X-Ray exposure in milliseconds.
+  type: number
+  unit: ms

--- a/src/schema/rules/files/raw/ct.yaml
+++ b/src/schema/rules/files/raw/ct.yaml
@@ -11,6 +11,8 @@ ct:
   entities:
     subject: required
     session: optional
+    acquisition: optional
     ceagent: optional
     reconstruction: optional
     run: optional
+    processing: optional

--- a/src/schema/rules/sidecars/ct.yaml
+++ b/src/schema/rules/sidecars/ct.yaml
@@ -30,17 +30,18 @@ CTIndexes:
     DLPUnit: optional
     SSDE: optional
     SSDEUnit: optional
+
 CTAcquisition:
   selectors:
     - datatype == "ct"
     - suffix == "ct"
   fields:
-    TubeVoltage:
+    XRayTubeVoltage:
       level: recommended
       description_addendum: |
         X-Ray tube peak kilo voltage (kVp) output.
         Corresponds to DICOM Tag 0018,0060 `KVP`.
-    TubeCurrent:
+    XRayTubeCurrent:
       level: recommended
       description_addendum: |
         X-Ray tube current in milliamperes.
@@ -54,12 +55,12 @@ CTAcquisition:
     ContrastBolusIngredient: optional
     ContrastBolusAgent: optional
     ContrastBolusRoute: optional
-    Exposure:
+    XRayExposure:
       level: optional
       description_addendum: |
         X-Ray exposure of the patient in milliamperes seconds.
         Corresponds to DICOM Tag 0018,1152 `Exposure`.
-    ExposureTime:
+    XRayExposureTime:
       level: optional
       description_addendum: |
         Time of X-Ray exposure in msec.

--- a/src/schema/rules/sidecars/ct.yaml
+++ b/src/schema/rules/sidecars/ct.yaml
@@ -131,8 +131,6 @@ CTReconstruction:
 
     ReconFilterType:
       level: optional
-      description_addendum:
-        $ref: objects.metadata.ReconFilterType.description
 
 CTInstitutionInformation:
   selectors:

--- a/src/schema/rules/sidecars/ct.yaml
+++ b/src/schema/rules/sidecars/ct.yaml
@@ -30,7 +30,6 @@ CTIndexes:
     DLPUnit: optional
     SSDE: optional
     SSDEUnit: optional
-
 CTAcquisition:
   selectors:
     - datatype == "ct"


### PR DESCRIPTION
Small changes following the online discussion over google docs and email, focusing on implementation over the fine details of navigating the peculiarities of CT.

This change leads to proper validation of this set of bids examples originally sourced from @neurolabusc 's repo at [https://github.com/rordenlab/soop-ct](https://github.com/rordenlab/soop-ct) via the `DICOMS.zip` file. 

```
(bids-specification) galassiae@MH02276145MLI bids-specification % tree ../bids-examples/ct001 
../bids-examples/ct001
├── dataset_description.json
├── derivatives
│   └── syncro
│       └── SYNcro_temp
│           ├── sub-1_ct.nii.gz
│           ├── sub-2_ct.nii.gz
│           ├── sub-3_ct.nii.gz
│           ├── sub-4_ct.nii.gz
│           └── sub-5_ct.nii.gz
├── participants.json
├── participants.tsv
├── sub-1
│   └── ct
│       ├── sub-1_acq-perfusion_ct.nii.gz
│       ├── sub-1_acq-post_ce-gd_ct.nii.gz
│       ├── sub-1_acq-pre_ce-none_ct.nii.gz
│       ├── sub-1_ct.json
│       └── sub-1_ct.nii.gz
├── sub-2
│   └── ct
│       ├── sub-2_acq-pre_ce-none_ct.json
│       └── sub-2_acq-pre_ce-none_ct.nii.gz
├── sub-3
│   └── ct
│       ├── sub-3_acq-perfusion_proc-somethingspecial_ct.json
│       └── sub-3_acq-perfusion_proc-somethingspecial_ct.nii.gz
├── sub-4
│   └── ct
│       ├── sub-4_ct.json
│       └── sub-4_ct.nii.gz
└── sub-5
    └── ct
        ├── sub-5_ct.json
        └── sub-5_ct.nii.gz

13 directories, 21 files
``` 

I'd like to make sure that the spec renders with mkdocs before merging this, but as it it passes validation for the example above, see:

```
(bids-specification) galassiae@MH02276145MLI bids-specification % make quickvalidateschema   
uv run bst export > src/schema.json
bids-validator-deno --schema file:///Users/galassiae/Projects/bep024_CT/bids-specification/src/schema.json ../bids-examples/ct001/ --verbose --ignoreWarnings --ignoreNiftiHeaders; \

This dataset appears to be BIDS compatible.

          Summary:                         Available Tasks:        Available Modalities:
          16 Files, 42.4 MB                                        ct                   
          5 - Subjects 1 - Sessions                                                     

        If you have any questions, please post on https://neurostars.org/tags/bids.

(bids-specification) galassiae@MH02276145MLI bids-specification % 
```


Cheers